### PR TITLE
Ignore gradle wrapper JAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gradle/wrapper/gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # App
+After cloning, run `gradle wrapper` or `./gradlew` to regenerate the wrapper JAR.


### PR DESCRIPTION
## Summary
- add `.gitignore` entry for `gradle-wrapper.jar`
- document how to regenerate the wrapper JAR

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d824e452c8330a06162b5b8e1be58